### PR TITLE
Reset game data on return to title

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,6 +96,7 @@ function showTitle() {
   if (animationId) {
     cancelAnimationFrame(animationId);
   }
+  initGame();
   canvas.style.display = 'none';
   titleScreen.style.display = 'flex';
 }


### PR DESCRIPTION
## Summary
- reset game state in `showTitle()` so pressing OK after game over clears prior data

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6850c215f4908333a119e53c61e2768b